### PR TITLE
Fix incorrect kIsWeb usage instead of withData

### DIFF
--- a/lib/src/form_builder_file_picker.dart
+++ b/lib/src/form_builder_file_picker.dart
@@ -243,7 +243,7 @@ class _FormBuilderFilePickerState extends FormBuilderFieldDecorationState<
                       child: (imageFileExts.contains(
                                   files[index].extension!.toLowerCase()) &&
                               widget.previewImages)
-                          ? kIsWeb
+                          ? widget.withData
                               ? Image.memory(files[index].bytes!,
                                   fit: BoxFit.cover)
                               : Image.file(File(files[index].path!),


### PR DESCRIPTION
I was using this widget with image preview with data bytes being available on MacOS platform. There is a field called `withData` to signal widget that bytes are available. Default value equals to `kIsWeb`.

Somehow instead of using `withData` on https://github.com/flutter-form-builder-ecosystem/form_builder_file_picker/blob/7311405ed04a78a90e6ce7bcc48250ee11b12d20/lib/src/form_builder_file_picker.dart#L246, `kIsWeb` was used. So on MacOS platform this was trying to read file from path (which is null) instead of bytes. That resulted in a red error box and stacktrace:

```
Another exception was thrown: Null check operator used on a null value
Another exception was thrown: A RenderFlex overflowed by 99827 pixels on the bottom.


══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY ╞═══════════════════════════════════════════════════════════
The following _TypeError was thrown building LayoutBuilder:
Null check operator used on a null value

The relevant error-causing widget was:
  LayoutBuilder
  LayoutBuilder:file:///Users/divan/.pub-cache/hosted/pub.dev/form_builder_file_picker-4.0.0/lib/src/form_builder_file_picker.dart:220:12

When the exception was thrown, this was the stack:
#0      _FormBuilderFilePickerState.defaultFileViewer.<anonymous closure>.<anonymous closure> (package:form_builder_file_picker/src/form_builder_file_picker.dart:249:66)
#1      new _GrowableList.generate (dart:core-patch/growable_array.dart:136:28)
#2      _FormBuilderFilePickerState.defaultFileViewer.<anonymous closure> (package:form_builder_file_picker/src/form_builder_file_picker.dart:231:26)
```
