### PR TITLE
Allow to customise the view of pickers

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -58,6 +58,10 @@ class MyHomePageState extends State<MyHomePage> {
                     ),
                   )
                 ],
+                customTypeViewerBuilder: (children) => Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: children,
+                ),
                 onFileLoading: (val) {
                   debugPrint(val.toString());
                 },

--- a/lib/src/form_builder_file_picker.dart
+++ b/lib/src/form_builder_file_picker.dart
@@ -75,34 +75,35 @@ class FormBuilderFilePicker
   final Widget Function(List<Widget> types)? customTypeViewerBuilder;
 
   /// Creates field for image(s) from user device storage
-  FormBuilderFilePicker({
-    //From Super
-    super.key,
-    required super.name,
-    super.validator,
-    super.initialValue,
-    super.decoration,
-    super.onChanged,
-    super.valueTransformer,
-    super.enabled,
-    super.onSaved,
-    super.autovalidateMode = AutovalidateMode.disabled,
-    super.onReset,
-    super.focusNode,
-    this.maxFiles,
-    this.withData = kIsWeb,
-    this.withReadStream = false,
-    this.allowMultiple = false,
-    this.previewImages = true,
-    this.typeSelectors = const [
-      TypeSelector(type: FileType.any, selector: Icon(Icons.add_circle))
-    ],
-    this.allowedExtensions,
-    this.onFileLoading,
-    this.allowCompression = true,
-    this.customFileViewerBuilder,
-    this.customTypeViewerBuilder
-  }) : super(
+  FormBuilderFilePicker(
+      {
+      //From Super
+      super.key,
+      required super.name,
+      super.validator,
+      super.initialValue,
+      super.decoration,
+      super.onChanged,
+      super.valueTransformer,
+      super.enabled,
+      super.onSaved,
+      super.autovalidateMode = AutovalidateMode.disabled,
+      super.onReset,
+      super.focusNode,
+      this.maxFiles,
+      this.withData = kIsWeb,
+      this.withReadStream = false,
+      this.allowMultiple = false,
+      this.previewImages = true,
+      this.typeSelectors = const [
+        TypeSelector(type: FileType.any, selector: Icon(Icons.add_circle))
+      ],
+      this.allowedExtensions,
+      this.onFileLoading,
+      this.allowCompression = true,
+      this.customFileViewerBuilder,
+      this.customTypeViewerBuilder})
+      : super(
           builder: (FormFieldState<List<PlatformFile>?> field) {
             final state = field as _FormBuilderFilePickerState;
 
@@ -114,11 +115,13 @@ class FormBuilderFilePicker
               child: Column(
                 children: <Widget>[
                   customTypeViewerBuilder != null
-                      ? customTypeViewerBuilder(state.getTypeSelectorActions(typeSelectors, field))
+                      ? customTypeViewerBuilder(
+                          state.getTypeSelectorActions(typeSelectors, field))
                       : Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: state.getTypeSelectorActions(typeSelectors, field),
-                  ),
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: state.getTypeSelectorActions(
+                              typeSelectors, field),
+                        ),
                   const SizedBox(height: 3),
                   customFileViewerBuilder != null
                       ? customFileViewerBuilder.call(state._files,
@@ -300,18 +303,17 @@ class _FormBuilderFilePickerState extends FormBuilderFieldDecorationState<
     );
   }
 
-  List<Widget> getTypeSelectorActions(List<TypeSelector> typeSelectors, FormFieldState<List<PlatformFile>?> field) {
+  List<Widget> getTypeSelectorActions(List<TypeSelector> typeSelectors,
+      FormFieldState<List<PlatformFile>?> field) {
     return <Widget>[
       ...typeSelectors.map(
-            (typeSelector) =>
-            InkWell(
-              onTap: enabled &&
-                  (null == _remainingItemCount ||
-                      _remainingItemCount! > 0)
-                  ? () => pickFiles(field, typeSelector.type)
-                  : null,
-              child: typeSelector.selector,
-            ),
+        (typeSelector) => InkWell(
+          onTap: enabled &&
+                  (null == _remainingItemCount || _remainingItemCount! > 0)
+              ? () => pickFiles(field, typeSelector.type)
+              : null,
+          child: typeSelector.selector,
+        ),
       ),
     ];
   }

--- a/lib/src/form_builder_file_picker.dart
+++ b/lib/src/form_builder_file_picker.dart
@@ -71,6 +71,9 @@ class FormBuilderFilePicker
   /// to support user interactions with the picked files.
   final FileViewerBuilder? customFileViewerBuilder;
 
+  /// Allow to customise the view of the pickers.
+  final Widget Function(List<Widget> types)? customTypeViewerBuilder;
+
   /// Creates field for image(s) from user device storage
   FormBuilderFilePicker({
     //From Super
@@ -98,6 +101,7 @@ class FormBuilderFilePicker
     this.onFileLoading,
     this.allowCompression = true,
     this.customFileViewerBuilder,
+    this.customTypeViewerBuilder
   }) : super(
           builder: (FormFieldState<List<PlatformFile>?> field) {
             final state = field as _FormBuilderFilePickerState;
@@ -109,20 +113,11 @@ class FormBuilderFilePicker
                       : null),
               child: Column(
                 children: <Widget>[
-                  Row(
+                  customTypeViewerBuilder != null
+                      ? customTypeViewerBuilder(state.getTypeSelectorActions(typeSelectors, field))
+                      : Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: <Widget>[
-                      ...typeSelectors.map(
-                        (typeSelector) => InkWell(
-                          onTap: state.enabled &&
-                                  (null == state._remainingItemCount ||
-                                      state._remainingItemCount! > 0)
-                              ? () => state.pickFiles(field, typeSelector.type)
-                              : null,
-                          child: typeSelector.selector,
-                        ),
-                      ),
-                    ],
+                    children: state.getTypeSelectorActions(typeSelectors, field),
                   ),
                   const SizedBox(height: 3),
                   customFileViewerBuilder != null
@@ -303,6 +298,22 @@ class _FormBuilderFilePickerState extends FormBuilderFieldDecorationState<
         );
       },
     );
+  }
+
+  List<Widget> getTypeSelectorActions(List<TypeSelector> typeSelectors, FormFieldState<List<PlatformFile>?> field) {
+    return <Widget>[
+      ...typeSelectors.map(
+            (typeSelector) =>
+            InkWell(
+              onTap: enabled &&
+                  (null == _remainingItemCount ||
+                      _remainingItemCount! > 0)
+                  ? () => pickFiles(field, typeSelector.type)
+                  : null,
+              child: typeSelector.selector,
+            ),
+      ),
+    ];
   }
 
   IconData getIconData(String fileExtension) {


### PR DESCRIPTION
## Solution description
Add `customTypeViewerBuilder` parameter to allow us to customise the view of the pickers, instead of using the `Row` widget with the `MainAxisAlignment.spaceBetween` alignment.
 
## Screenshots or Videos
With this feature, we can achieve some custom looks like below:
![image](https://github.com/flutter-form-builder-ecosystem/form_builder_file_picker/assets/69736313/01d98975-40bc-4858-a39f-bb858bbddf66)

or align all pickers to the end:
![image](https://github.com/flutter-form-builder-ecosystem/form_builder_file_picker/assets/69736313/e7b326bf-91a5-4a35-980e-4322abf27557)




