### PR TITLE
Solving app crashes on some Huawei phones

### DIFF
--- a/lib/src/form_builder_file_picker.dart
+++ b/lib/src/form_builder_file_picker.dart
@@ -58,6 +58,8 @@ class FormBuilderFilePicker
   /// Whether to allow file compression
   final bool allowCompression;
 
+  final int? compressionQuality;
+
   /// If [withData] is set, picked files will have its byte data immediately available on memory as [Uint8List]
   /// which can be useful if you are picking it for server upload or similar.
   final bool withData;
@@ -101,6 +103,7 @@ class FormBuilderFilePicker
       this.allowedExtensions,
       this.onFileLoading,
       this.allowCompression = true,
+        this.compressionQuality,
       this.customFileViewerBuilder,
       this.customTypeViewerBuilder})
       : super(
@@ -180,6 +183,7 @@ class _FormBuilderFilePickerState extends FormBuilderFieldDecorationState<
         type: fileType,
         allowedExtensions: widget.allowedExtensions,
         allowCompression: widget.allowCompression,
+        compressionQuality: widget.compressionQuality ?? 30,
         onFileLoading: widget.onFileLoading,
         allowMultiple: widget.allowMultiple,
         withData: widget.withData,

--- a/lib/src/form_builder_file_picker.dart
+++ b/lib/src/form_builder_file_picker.dart
@@ -58,7 +58,7 @@ class FormBuilderFilePicker
   /// Whether to allow file compression
   final bool allowCompression;
 
-  final int? compressionQuality;
+  final int compressionQuality;
 
   /// If [withData] is set, picked files will have its byte data immediately available on memory as [Uint8List]
   /// which can be useful if you are picking it for server upload or similar.
@@ -103,7 +103,7 @@ class FormBuilderFilePicker
       this.allowedExtensions,
       this.onFileLoading,
       this.allowCompression = true,
-        this.compressionQuality,
+      this.compressionQuality = 30,
       this.customFileViewerBuilder,
       this.customTypeViewerBuilder})
       : super(
@@ -183,7 +183,7 @@ class _FormBuilderFilePickerState extends FormBuilderFieldDecorationState<
         type: fileType,
         allowedExtensions: widget.allowedExtensions,
         allowCompression: widget.allowCompression,
-        compressionQuality: widget.compressionQuality ?? 30,
+        compressionQuality: widget.compressionQuality,
         onFileLoading: widget.onFileLoading,
         allowMultiple: widget.allowMultiple,
         withData: widget.withData,


### PR DESCRIPTION
## Issue Description
There is this issue on ```file_picker``` package: https://github.com/miguelpruivo/flutter_file_picker/issues/1461

Simply the app crashes on some Huawei phones when we choose an image. The issue is with the ```compressionQuality``` in ```FilePicker.platform.pickFiles``` function. 

## Solution description
Just by passing zero to compressionQuality parameter, the problem is solved, and the issue is not there anymore.
