### PR TITLE
feat: image cropper added

### DIFF
--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -25,6 +25,10 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <activity
+            android:name="com.yalantis.ucrop.UCropActivity"
+            android:screenOrientation="portrait"
+            android:theme="@style/Ucrop.CropTheme"/>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -46,6 +46,7 @@ class MyHomePageState extends State<MyHomePage> {
                 maxFiles: null,
                 allowMultiple: true,
                 previewImages: true,
+                enableImageCropper: true,
                 onChanged: (val) => debugPrint(val.toString()),
                 typeSelectors: const [
                   TypeSelector(

--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,8 @@
 import FlutterMacOS
 import Foundation
 
+import file_picker
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
 }

--- a/example/web/index.html
+++ b/example/web/index.html
@@ -31,6 +31,10 @@
 
   <title>form_builder_file_picker</title>
   <link rel="manifest" href="manifest.json">
+
+  <!-- cropperjs -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/cropperjs/1.6.2/cropper.css" />
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/cropperjs/1.6.2/cropper.min.js"></script>
 </head>
 <body>
   <script src="flutter_bootstrap.js" async></script>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ environment:
 dependencies:
   community_material_icon: ^5.9.55
   file_picker: ^8.1.6
+  image_cropper: ^8.0.2
   flutter:
     sdk: flutter
   flutter_form_builder: ^9.6.0


### PR DESCRIPTION
## Solution description
Allow cropping images when using `FileType.image`.
To get this feature working, you will need to follow the installation steps for each platform(added docs for `enableImageCropper`) and set the new property`enableImageCropper`  to `true`.

## Screenshots or Videos

https://github.com/user-attachments/assets/c9008854-48bf-42b5-9e0a-21d74b3a954f


<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [x] Add unit test to verify new or fixed behaviour
- [x] If apply, add documentation to code properties and package readme
